### PR TITLE
Update name of wp-graphql-smart-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Use the steps in this readme to configure for each WP.
 Install and activate the following plugins in the WP at WP Engine:
 
 - [wp-graphql](https://github.com/wp-graphql/wp-graphql)
-- [wp-graphql-labs](https://github.com/wp-graphql/wp-graphql-labs)
+- [wp-graphql-smart-cache](https://github.com/wp-graphql/wp-graphql-smart-cache)
 - [wpe-graphql-cache](https://github.com/wpengine/wpe-graphql-cache)
 
 ## Use GET requests
@@ -22,7 +22,7 @@ Make the graphql request again and verify the cache header is a `Miss`, then the
 
 ## Use saved query names/aliases
 
-Instead of passing the full graphql 'query { string }' on the url for the request, with the [wp-graphql-labs](https://github.com/wp-graphql/wp-graphql-labs) plugin, you can make use of easy to remember query names instead.
+Instead of passing the full graphql 'query { string }' on the url for the request, with the [wp-graphql-smart-cache](https://github.com/wp-graphql/wp-graphql-smart-cache) plugin, you can make use of easy to remember query names instead.
 
 For example,
 
@@ -36,7 +36,7 @@ Could be saved in the system and queried as
 https://content.example.com/graphql?queryId=posts-about-coffee
 ```
 
-To create queries, see documentation at the [wp-graphql-labs](https://github.com/wp-graphql/wp-graphql-labs/) plugin.
+To create queries, see documentation at the [wp-graphql-smart-cache](https://github.com/wp-graphql/wp-graphql-smart-cache/) plugin.
 
 Queries can be created using the GraphiQL IDE editor, using graphql mutations or the wp-admin editor (enable the setting to show queries in the wp-admin menu).
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ Works with Apollo Persisted Queries JavaScript client.
 
 Optimized your wp-graphql requests and Javascript client by using GET for your graphql requests to the WP. At WP Engine, these requests will be optimized in WP Engine's EverCache environment.
 
-This plugin integrates with the wp-graphql-labs caching extension plugin to correctly invalidate cached data when it changes in your plugin.
+This plugin integrates with the wp-graphql-smart-cache caching extension plugin to correctly invalidate cached data when it changes in your plugin.
 
 == Changelog ==
 


### PR DESCRIPTION
Change to match the [plugin rename](https://github.com/wp-graphql/wp-graphql-smart-cache/pull/147).